### PR TITLE
Fix metadata/datasets endpoint

### DIFF
--- a/src/main/java/no/uio/ifi/localega/doa/repositories/DatasetRepository.java
+++ b/src/main/java/no/uio/ifi/localega/doa/repositories/DatasetRepository.java
@@ -5,10 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
+import java.util.Optional;
 
 @Repository
 public interface DatasetRepository extends JpaRepository<LEGADataset, String> {
 
-    Collection<LEGADataset> findByDatasetId(String datasetId);
+    Optional<LEGADataset> findByDatasetId(String datasetId);
+
+    Collection<LEGADataset> findByDatasetIdIn(Collection<String> datasetId);
 
 }

--- a/src/main/java/no/uio/ifi/localega/doa/rest/MetadataController.java
+++ b/src/main/java/no/uio/ifi/localega/doa/rest/MetadataController.java
@@ -35,7 +35,8 @@ public class MetadataController {
         String subject = decodedJWT.getSubject();
         log.info("User {} is authenticated and is getting the list of datasets", subject);
         Set<String> datasetIds = Arrays.stream(decodedJWT.getClaim("authorities").asArray(String.class)).collect(Collectors.toSet());
-        return ResponseEntity.ok(datasetIds);
+        Collection<LEGADataset> datasets = datasetRepository.findByDatasetIdIn(datasetIds);
+        return ResponseEntity.ok(datasets.stream().map(LEGADataset::getDatasetId).collect(Collectors.toSet()));
     }
 
     @GetMapping("/datasets/{datasetId}/files")
@@ -50,8 +51,8 @@ public class MetadataController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         log.info("User has permissions to access this dataset, listing");
-        Collection<LEGADataset> datasets = datasetRepository.findByDatasetId(datasetId);
-        List<File> files = datasets
+        Optional<LEGADataset> dataset = datasetRepository.findByDatasetId(datasetId);
+        List<File> files = dataset
                 .stream()
                 .map(LEGADataset::getFileId)
                 .map(f -> fileRepository.findById(f))

--- a/src/main/java/no/uio/ifi/localega/doa/rest/StreamingController.java
+++ b/src/main/java/no/uio/ifi/localega/doa/rest/StreamingController.java
@@ -139,12 +139,10 @@ public class StreamingController {
     }
 
     private boolean checkPermissions(String fileId, Set<String> datasetIds) {
-        for (String datasetId : datasetIds) {
-            Collection<LEGADataset> datasets = datasetRepository.findByDatasetId(datasetId);
-            for (LEGADataset dataset : datasets) {
-                if (dataset.getFileId().equalsIgnoreCase(fileId)) {
-                    return true;
-                }
+        Collection<LEGADataset> datasets = datasetRepository.findByDatasetIdIn(datasetIds);
+        for (LEGADataset dataset : datasets) {
+            if (dataset.getFileId().equalsIgnoreCase(fileId)) {
+                return true;
             }
         }
         return false;


### PR DESCRIPTION
@blankdots, as you mentioned today, `metadata/datasets` endpoint should return not all the datasets from the token, but only those that are present in the database.