### PR TITLE
Use better default values for env-vars

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,8 @@ s3:
   access-key: ${S3_ACCESS_KEY:minio}
   secret-key: ${S3_SECRET_KEY:miniostorage}
   region: ${S3_REGION:us-west-1}
-  bucket: ${S3_BUCKET:localega}
-  secure: ${S3_SECURE:false}
+  bucket: ${S3_BUCKET:lega}
+  secure: ${S3_SECURE:true}
   root-ca: ${S3_ROOT_CERT_PATH:/etc/ssl/certs/ca-certificates.crt}
 
 jwt.public-key-path: ${JWT_PUBLIC_KEY_PATH:/etc/ega/jwt/key.pem}


### PR DESCRIPTION
- The default bucket name in the vault (created by Python microservices) is `lega` and not `localega`.
- SSL should be used by default.