### PR TITLE
Entrypoint script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,15 @@ jobs:
       - name: Spring Boot Run
         run: nohup mvn spring-boot:run --no-transfer-progress > nohup.out &
 
-      - name: Sleep again
-        run: sleep 30
+      - name: Waith for app to start
+        run: |
+          RETRY_TIMES=0
+          until lsof -i -P -n | grep ":8080";
+          do
+          RETRY_TIMES=$((RETRY_TIMES+1));
+          if [ $RETRY_TIMES -eq 30 ]; then exit 1; fi
+          sleep 10;
+          done
 
       - name: Test
         run: mvn test --no-transfer-progress

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,19 @@ RUN mvn clean install -DskipTests --no-transfer-progress
 
 FROM openjdk:13-alpine
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates openssl
 
 COPY --from=builder /target/localega-doa-*.jar /localega-doa.jar
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 RUN addgroup -g 1000 lega && \
     adduser -D -u 1000 -G lega lega
 
 USER 1000
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 CMD ["java", "-jar", "/localega-doa.jar"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ ! -s "${KEYSTORE_PATH}" ]; then
+        echo "Creating PKCS12 keystore"
+        openssl pkcs12 -export -out "${PKI_PATH}/doa.p12" \
+                -inkey "${PKI_PATH}/doa.key" \
+                -in "${PKI_PATH}/doa.crt" \
+                -passout pass:"${KEYSTORE_PASSWORD}"
+        echo "Creating DER key"
+        openssl pkcs8 -topk8 \
+                -inform pem \
+                -outform der \
+                -in "${PKI_PATH}/doa.key" \
+                -out "${PKI_PATH}/doa.der" \
+                -nocrypt
+fi
+
+exec "$@"


### PR DESCRIPTION
Currently This app needs multiple certificates in different formats to work, PKI infrastructure can create certificates in one form or the other but not two formats at the same time.

The entrypoint script is triggered if the java keystore needed for the tomcat server is defined but absent, it takes the ENV  `PKI_PATH` as destination when creating the keystore and the DER encoded client key which is needed when connecting to the DB.
