### PR TITLE
Make SSL mode be configurable in JDBC

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Environment variables used:
 | DB_INSTANCE                        | db                                                                   | Database hostname                                  |
 | DB_PORT                            | 5432                                                                 | Database port                                      |
 | POSTGRES_DB                        | lega                                                                 | Database name                                      |
+| SSL_MODE                           | verify-full                                                          | SSL mode for DB connectivity                       |
 | ROOT_CERT_PATH                     | /etc/ega/ssl/CA.cert                                                 | Path to the CA file for database connectivity      |
 | CERT_PATH                          | /etc/ega/ssl/client.cert                                             | Path to the client cert for database connectivity  |
 | CERT_KEY                           | /etc/ega/ssl/client.key                                              | Path to the client key for database connectivity   |

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ server.ssl:
 
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_INSTANCE:db}:${DB_PORT:5432}/${POSTGRES_DB:lega}?sslmode=verify-full&sslrootcert=${ROOT_CERT_PATH:/etc/ega/ssl/CA.cert}&sslcert=${CERT_PATH:/etc/ega/ssl/client.cert}&sslkey=${CERT_KEY:/etc/ega/ssl/client.key}
+    url: jdbc:postgresql://${DB_INSTANCE:db}:${DB_PORT:5432}/${POSTGRES_DB:lega}?sslmode=${SSL_MODE:verify-full}&sslrootcert=${ROOT_CERT_PATH:/etc/ega/ssl/CA.cert}&sslcert=${CERT_PATH:/etc/ega/ssl/client.cert}&sslkey=${CERT_KEY:/etc/ega/ssl/client.key}
     username: ${POSTGRES_USER:lega_out}
     password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
It is needed for TSD deployment to be able to configure SSL mode for DB connectivity, instead of just hardcoding it to `verify-full` (it's still a default value though);