### PR TITLE
revert to previously way of building paths

### DIFF
--- a/src/main/java/no/uio/ifi/localega/doa/services/StreamingService.java
+++ b/src/main/java/no/uio/ifi/localega/doa/services/StreamingService.java
@@ -130,6 +130,7 @@ public class StreamingService {
             } else {
                 processedPath = archivePath + filePath;
             }
+            processedPath = processedPath.replace("//", "/");
             log.info("Archive path is: {}", processedPath);
             return Files.newInputStream(new File(processedPath).toPath());
         }

--- a/src/main/java/no/uio/ifi/localega/doa/services/StreamingService.java
+++ b/src/main/java/no/uio/ifi/localega/doa/services/StreamingService.java
@@ -127,9 +127,6 @@ public class StreamingService {
             String processedPath;
             if ("/".equalsIgnoreCase(archivePath)) {
                 processedPath = filePath;
-            } else if (archivePath.endsWith("/")) {
-                String tempPath = archivePath.substring(0, archivePath.length() - 1);
-                processedPath = tempPath + filePath;
             } else {
                 processedPath = archivePath + filePath;
             }


### PR DESCRIPTION
revert to previously way of building paths to match sda-pipeline archive paths.
see https://github.com/neicnordic/LocalEGA-DOA/pull/16